### PR TITLE
Apply the default team only to the package library

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -1,0 +1,7 @@
+/*
+* Configuration of the storybook canvas.
+*/
+html {
+  font-size: 14px;
+  font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,5 @@
+import './preview.css';
+
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   controls: {

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -9,7 +9,6 @@
     color: var(--color-text-default);
     cursor: pointer;
     display: inline-block;
-    font-family: var(--font-family);
     line-height: 1em;
     @include s.padding(s.$medium);
 

--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -14,6 +14,7 @@
     border-radius: var(--medium-border-radius);
     border: 1px solid var(--menu-border-color);
     min-width: 100%;
+    overflow: hidden;
   }
 
   li {

--- a/src/styles/utilities/_global.scss
+++ b/src/styles/utilities/_global.scss
@@ -5,9 +5,9 @@
   --medium-border-radius: 0.28571429rem;
 
   // TODO: this is part of a theme
-  --menu-border-color: rgba(34, 36, 38, 0.15);
+  --menu-border-color: #d8d8d9;
   --menu-box-shadow: 0 2px 4px 0 var(--menu-border-color), 0 2px 10px 0 var(--menu-border-color);
-  --menu-item-hover-color: rgba(0, 0, 0, 0.05);
+  --menu-item-hover-color: #f2f2f2;
 }
 
 // Size names

--- a/src/styles/utilities/_variables.scss
+++ b/src/styles/utilities/_variables.scss
@@ -1,17 +1,8 @@
-// common variables:
-:root {
-  --font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  --font-size: 14px;
-}
-
-html {
-  font-family: var(--font-family);
-  font-size: var(--font-size);
+@mixin main-styles {
   box-sizing: border-box;
+  color: var(--color-text);
 }
 
-* {
-  font-family: inherit;
-  font-size: inherit;
-  box-sizing: inherit;
+[class*="vmcrjc"], [class*="vmcrjc"] *:not(i) {
+  @include main-styles;
 }


### PR DESCRIPTION
- all the global selector were deleted like "html {"
- the library components currently has stated colors so that the
  components won't change with global styles from outside (except
  font-size and font-family)
- fix overflowed borders of the menu items in the rounded border list
- apply general styles: font-size, font-family to the storybook main
  canvas.